### PR TITLE
Support example data from schema's properties

### DIFF
--- a/internal/openapi3/example.go
+++ b/internal/openapi3/example.go
@@ -17,3 +17,30 @@ func (e Examples) GetKeys() []string {
 
 	return keys
 }
+
+func ExampleToResponse(data any) any {
+	switch data := data.(type) {
+	case map[any]any:
+		return parseExample(data)
+	case []any:
+		res := make([]map[string]any, len(data))
+		for k, v := range data {
+			res[k] = parseExample(v.(map[any]any))
+		}
+
+		return res
+	case string:
+		return data
+	}
+
+	return nil
+}
+
+func parseExample(example map[any]any) map[string]any {
+	res := make(map[string]any, len(example))
+	for k, v := range example {
+		res[k.(string)] = v
+	}
+
+	return res
+}

--- a/internal/openapi3/mediatype.go
+++ b/internal/openapi3/mediatype.go
@@ -9,38 +9,13 @@ type MediaType struct {
 }
 
 func (mt MediaType) ResponseByExample() any {
-	return mt.example(mt.Example)
+	return ExampleToResponse(mt.Example)
 }
 
 func (mt MediaType) ResponseByExamplesKey(key string) any {
 	return mt.examples(key)
 }
 
-func (mt MediaType) example(i any) any {
-	switch data := i.(type) {
-	case map[any]any:
-		return parseExample(data)
-	case []any:
-		res := make([]map[string]any, len(data))
-		for k, v := range data {
-			res[k] = parseExample(v.(map[any]any))
-		}
-
-		return res
-	}
-
-	return nil
-}
-
 func (mt MediaType) examples(key string) any {
-	return mt.example(mt.Examples[key].Value)
-}
-
-func parseExample(example map[any]any) map[string]any {
-	res := make(map[string]any, len(example))
-	for k, v := range example {
-		res[k.(string)] = v
-	}
-
-	return res
+	return ExampleToResponse(mt.Examples[key].Value)
 }

--- a/internal/openapi3/mediatype.go
+++ b/internal/openapi3/mediatype.go
@@ -1,6 +1,9 @@
 package openapi3
 
+// Media Type Object
+// See specification https://swagger.io/specification/#media-type-object
 type MediaType struct {
+	Schema   Schema      `json:"schema" yaml:"schema"`
 	Example  any      `json:"example,omitempty" yaml:"example,omitempty"`
 	Examples Examples `json:"examples,omitempty" yaml:"examples,omitempty"`
 }

--- a/internal/openapi3/mediatype.go
+++ b/internal/openapi3/mediatype.go
@@ -3,7 +3,7 @@ package openapi3
 // Media Type Object
 // See specification https://swagger.io/specification/#media-type-object
 type MediaType struct {
-	Schema   Schema      `json:"schema" yaml:"schema"`
+	Schema   Schema   `json:"schema" yaml:"schema"`
 	Example  any      `json:"example,omitempty" yaml:"example,omitempty"`
 	Examples Examples `json:"examples,omitempty" yaml:"examples,omitempty"`
 }

--- a/internal/openapi3/openapi3.go
+++ b/internal/openapi3/openapi3.go
@@ -1,9 +1,28 @@
 package openapi3
 
+import (
+	"fmt"
+	"strings"
+)
+
 // OpenAPI Object
 // See specification https://swagger.io/specification/#openapi-object
 type OpenAPI struct {
 	Info       Info       `json:"info" yaml:"info"`
 	Paths      Paths      `json:"paths" yaml:"paths"`
 	Components Components `json:"components,omitempty" yaml:"components,omitempty"`
+}
+
+func (api OpenAPI) LookupByReference(ref string) (Schema, error) {
+	schema := api.Components.Schemas[schemaKey(ref)]
+	if schema == nil {
+		return Schema{}, fmt.Errorf("unknown schema %q", schema.Reference)
+	}
+
+	return *schema, nil
+}
+
+func schemaKey(ref string) string {
+	const prefix = "#/components/schemas/"
+	return strings.TrimPrefix(ref, prefix)
 }

--- a/internal/openapi3/parse_test.go
+++ b/internal/openapi3/parse_test.go
@@ -1,8 +1,9 @@
 package openapi3_test
 
 import (
-	"github.com/go-dummy/dummy/internal/openapi3"
 	"testing"
+
+	"github.com/go-dummy/dummy/internal/openapi3"
 
 	"github.com/stretchr/testify/require"
 )
@@ -16,26 +17,31 @@ func TestParse_Yaml(t *testing.T) {
 		Paths: openapi3.Paths{
 			"/users": &openapi3.Path{
 				Post: &openapi3.Operation{
-					Parameters: nil,
 					Responses: openapi3.Responses{
 						"201": &openapi3.Response{
 							Description: ptrStr(""),
 							Content: openapi3.Content{
 								"application/json": &openapi3.MediaType{
-									Example:  nil,
-									Examples: nil,
+									Schema: openapi3.Schema{
+										Reference: "#/components/schemas/User",
+									},
 								},
 							},
 						},
 					},
 				},
 				Get: &openapi3.Operation{
-					Parameters: nil,
 					Responses: openapi3.Responses{
 						"200": &openapi3.Response{
 							Description: ptrStr(""),
 							Content: openapi3.Content{
 								"application/json": &openapi3.MediaType{
+									Schema: openapi3.Schema{
+										Type: "array",
+										Items: &openapi3.Schema{
+											Reference: "#/components/schemas/User",
+										},
+									},
 									Example: []any{
 										map[any]any{
 											"id":        "e1afccea-5168-4735-84d4-cb96f6fb5d25",
@@ -48,7 +54,6 @@ func TestParse_Yaml(t *testing.T) {
 											"lastName":  "Brin",
 										},
 									},
-									Examples: nil,
 								},
 							},
 						},
@@ -71,7 +76,11 @@ func TestParse_Yaml(t *testing.T) {
 						"200": &openapi3.Response{
 							Description: ptrStr(""),
 							Content: openapi3.Content{
-								"application/json": &openapi3.MediaType{},
+								"application/json": &openapi3.MediaType{
+									Schema: openapi3.Schema{
+										Reference: "#/components/schemas/User",
+									},
+								},
 							},
 						},
 					},
@@ -83,14 +92,17 @@ func TestParse_Yaml(t *testing.T) {
 				"User": &openapi3.Schema{
 					Properties: openapi3.Schemas{
 						"id": &openapi3.Schema{
-							Type:   "string",
-							Format: "uuid",
+							Type:    "string",
+							Format:  "uuid",
+							Example: "380ed0b7-eb21-4ad4-acd0-efa90cf69c6a",
 						},
 						"firstName": &openapi3.Schema{
-							Type: "string",
+							Type:    "string",
+							Example: "Larry",
 						},
 						"lastName": &openapi3.Schema{
-							Type: "string",
+							Type:    "string",
+							Example: "Page",
 						},
 					},
 					Type: "object",

--- a/internal/openapi3/schema.go
+++ b/internal/openapi3/schema.go
@@ -7,6 +7,10 @@ type Schema struct {
 	Default    any     `json:"default,omitempty" yaml:"default,omitempty"`
 	Example    any     `json:"example,omitempty" yaml:"example,omitempty"`
 	Faker      string  `json:"x-faker,omitempty" yaml:"x-faker,omitempty"`
+
+	Items *Schema `json:"items,omitempty" yaml:"items,omitempty"`
+
+	Reference string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 }
 
 type Schemas map[string]*Schema

--- a/internal/openapi3/schema_test.go
+++ b/internal/openapi3/schema_test.go
@@ -1,0 +1,186 @@
+package openapi3
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	userSchema = Schema{
+		Properties: Schemas{
+			"id": &Schema{
+				Type:    "string",
+				Format:  "uuid",
+				Example: "380ed0b7-eb21-4ad4-acd0-efa90cf69c6a",
+			},
+			"firstName": &Schema{
+				Type:    "string",
+				Example: "Larry",
+			},
+			"lastName": &Schema{
+				Type:    "string",
+				Example: "Page",
+			},
+		},
+		Type: "object",
+	}
+
+	uuidSchema = Schema{
+		Type:    "string",
+		Format:  "uuid",
+		Example: "380ed0b7-eb21-4ad4-acd0-efa90cf69c6a",
+	}
+)
+
+type schemaContextStub struct{}
+
+func (s schemaContextStub) LookupByReference(ref string) (Schema, error) {
+	switch ref {
+	case "#/components/schemas/User":
+		return userSchema, nil
+	case "#/components/schemas/UUID":
+		return uuidSchema, nil
+	default:
+		return Schema{}, fmt.Errorf("unknown schema: %q", ref)
+	}
+}
+
+func TestSchema_ResponseByExample(t *testing.T) {
+	type fields struct {
+		Properties Schemas
+		Type       string
+		Format     string
+		Default    interface{}
+		Example    interface{}
+		Faker      string
+		Items      *Schema
+		Reference  string
+	}
+
+	type args struct {
+		schemaContext schemaContext
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantRes interface{}
+		wantErr bool
+	}{
+		{
+			name: "Simple schema",
+			fields: fields{
+				Properties: Schemas{
+					"id": &Schema{
+						Type:    "string",
+						Format:  "uuid",
+						Example: "380ed0b7-eb21-4ad4-acd0-efa90cf69c6a",
+					},
+					"firstName": &Schema{
+						Type:    "string",
+						Example: "Larry",
+					},
+					"lastName": &Schema{
+						Type:    "string",
+						Example: "Page",
+					},
+				},
+				Type: "object",
+			},
+			args: args{
+				schemaContext: schemaContextStub{},
+			},
+			wantRes: map[string]interface{}{
+				"id":        "380ed0b7-eb21-4ad4-acd0-efa90cf69c6a",
+				"firstName": "Larry",
+				"lastName":  "Page",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Simple schema with reference",
+			fields: fields{
+				Reference: "#/components/schemas/User",
+			},
+			args: args{
+				schemaContext: schemaContextStub{},
+			},
+			wantRes: map[string]interface{}{
+				"id":        "380ed0b7-eb21-4ad4-acd0-efa90cf69c6a",
+				"firstName": "Larry",
+				"lastName":  "Page",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Array schema with reference",
+			fields: fields{
+				Type: "array",
+				Items: &Schema{
+					Reference: "#/components/schemas/User",
+				},
+			},
+			args: args{
+				schemaContext: schemaContextStub{},
+			},
+			wantRes: []interface{}{
+				map[string]interface{}{
+					"id":        "380ed0b7-eb21-4ad4-acd0-efa90cf69c6a",
+					"firstName": "Larry",
+					"lastName":  "Page",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Schema property with reference",
+			fields: fields{
+				Properties: Schemas{
+					"id": &Schema{
+						Reference: "#/components/schemas/UUID",
+					},
+					"firstName": &Schema{
+						Type:    "string",
+						Example: "Larry",
+					},
+					"lastName": &Schema{
+						Type:    "string",
+						Example: "Page",
+					},
+				},
+				Type: "object",
+			},
+			args: args{
+				schemaContext: schemaContextStub{},
+			},
+			wantRes: map[string]interface{}{
+				"id":        "380ed0b7-eb21-4ad4-acd0-efa90cf69c6a",
+				"firstName": "Larry",
+				"lastName":  "Page",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Schema{
+				Properties: tt.fields.Properties,
+				Type:       tt.fields.Type,
+				Format:     tt.fields.Format,
+				Default:    tt.fields.Default,
+				Example:    tt.fields.Example,
+				Faker:      tt.fields.Faker,
+				Items:      tt.fields.Items,
+				Reference:  tt.fields.Reference,
+			}
+			gotRes, err := s.ResponseByExample(tt.args.schemaContext)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantRes, gotRes)
+		})
+	}
+}

--- a/internal/openapi3/testdata/openapi3.yml
+++ b/internal/openapi3/testdata/openapi3.yml
@@ -65,7 +65,10 @@ components:
         id:
           type: string
           format: uuid
+          example: 380ed0b7-eb21-4ad4-acd0-efa90cf69c6a
         firstName:
           type: string
+          example: Larry
         lastName:
           type: string
+          example: Page

--- a/test/testdata/get-properties-examples/openapi3.yml
+++ b/test/testdata/get-properties-examples/openapi3.yml
@@ -1,0 +1,39 @@
+openapi: 3.0.3
+info:
+  title: Users dummy API
+  version: 0.1.0
+paths:
+  /users:
+    get:
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - id
+        - firstName
+        - lastName
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        firstName:
+          type: string
+          example: Elon
+        lastName:
+          type: string
+          example: Musk
+
+    UUID:
+      type: string
+      format: uuid
+      example: e1afccea-5168-4735-84d4-cb96f6fb5d25

--- a/test/testdata/get-properties-examples/pact.json
+++ b/test/testdata/get-properties-examples/pact.json
@@ -1,0 +1,27 @@
+{
+  "consumer": {
+    "name": "consumer"
+  },
+  "provider": {
+    "name": "dummy"
+  },
+  "interactions": [
+    {
+      "description": "Example is object",
+      "request": {
+        "method": "GET",
+        "path": "/users"
+      },
+      "response": {
+        "status": 200,
+        "body": [
+          {
+            "firstName": "Elon",
+            "id": "e1afccea-5168-4735-84d4-cb96f6fb5d25",
+            "lastName": "Musk"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Traverse by schema's properties recursively and collect response (`ResponseByExample`).
Resolve schema by reference in place.
Also, add special case for array type - need create slice and traverse `items`.

### Checklist:
- [x] Tests for the changes have been added (for bug fixes / features / refactoring)
